### PR TITLE
fix(nvm): global packages role

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -116,6 +116,7 @@ RUN usermod -a -G docker $USER
 # ------------------------------
 COPY home/ ${HOME}/
 RUN chown -R ${PUID}:${PGID} $HOME
+RUN chown -R ${PUID}:${PGID} /usr/local/nvm
 
 # ------------------------------
 # Ready


### PR DESCRIPTION
## Description
Install global package require permissions to folder /usr/local/nvm/versions/node/XXX/lib/node_modules